### PR TITLE
Fix errors in the documentation

### DIFF
--- a/doc/source/quickstart_pymc3.rst
+++ b/doc/source/quickstart_pymc3.rst
@@ -53,6 +53,7 @@ We'll use some time artificial data:::
     hare_data = np.array([
         30.0, 47.2, 70.2, 77.4, 36.3, 20.6, 18.1, 21.4, 22.0, 25.4,
         27.1, 40.3, 57.0, 76.6, 52.3, 19.5, 11.2, 7.6, 14.6, 16.2, 24.7
+    ])
     
 We also define a function for the right-hand-side of the ODE:::
 
@@ -138,12 +139,12 @@ We are only missing the likelihood now::
     with model:
         # We can access the individual variables of the solution using the
         # variable names.
-        pm.Deterministic('hares_mu', y_hat['hares'])
-        pm.Deterministic('lynx_mu', y_hat['lynx'])
+        pm.Deterministic('hares_mu', solution['hares'])
+        pm.Deterministic('lynxes_mu', solution['lynxes'])
 
         sd = pm.HalfNormal('sd')
-        pm.Lognormal('hares', mu=y_hat['hares'], sd=sd, observed=hare_data)
-        pm.Lognormal('lynx', mu=y_hat['lynx'], sd=sd, observed=lynx_data)
+        pm.Lognormal('hares', mu=solution['hares'], sd=sd, observed=hare_data)
+        pm.Lognormal('lynxes', mu=solution['lynxes'], sd=sd, observed=lynx_data)
 
 We can sample from the posterior with the gradient-based PyMC3 samplers:::
 

--- a/doc/source/without_pymc.rst
+++ b/doc/source/without_pymc.rst
@@ -62,7 +62,7 @@ ODE might look like this::
         dhares = p.alpha * hares - p.beta * lynxes * hares
         dlynxes = p.delta * hares * lynxes - p.gamma * lynxes
         return {
-            'log_hares': dhares / hares
+            'log_hares': dhares / hares,
             'log_lynxes': dlynxes / lynxes,
         }
 
@@ -88,7 +88,8 @@ After defining states, parameters and right-hand-side function we can create a
     problem = sunode.SympyProblem(
         params=params,
         states=states,
-        rhs_sympy=lotka_volterra
+        rhs_sympy=lotka_volterra,
+        derivative_params=()
     )
 
 The problem provides structured numpy dtypes for states and parameters
@@ -106,7 +107,7 @@ This does not introduce runtime overhead.::
 
     y0 = np.zeros((), dtype=problem.state_dtype)
     y0['hares'] = 1
-    y0['lynx'] = 0.1
+    y0['lynxes'] = 0.1
 
     # At which time points do we want to evalue the solution
     tvals = np.linspace(0, 10)
@@ -127,4 +128,4 @@ We can convert the solution to an xarray Dataset or access the
 individual states as numpy record array::
 
     solver.as_xarray(tvals, output).solution_hares.plot()
-    plt.plot(output.view(problem.state_dtype)['hares']
+    plt.plot(output.view(tvals, problem.state_dtype)['hares'])


### PR DESCRIPTION
This fixes some typos in the examples from the documentation so that they can be run when copied to a notebook.