### PR TITLE
Make imports compatible with Theano, Theano-PyMC and Aesara

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+omit =
+    # exclude tests files from coverage calculation
+    sunode/test*.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Install build and test dependencies
       shell: cmd /C call {0}
       run: |
-        conda install conda-build conda-verify coverage pytest pytest-cov hypothesis statsmodels sundials theano
+        conda install conda-build conda-verify coverage pytest pytest-cov hypothesis statsmodels sundials
     - name: Sunode build
       shell: cmd /C call {0}
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install miniconda
-      uses: goanpeca/setup-miniconda@v1
+      uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: true
         activate-environment: sunode-dev
@@ -50,7 +50,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install miniconda
-      uses: goanpeca/setup-miniconda@v1
+      uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: true
         activate-environment: sunode-dev

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,8 @@ jobs:
     - name: Install sunode
       shell: cmd /C call {0}
       run: |
-        conda install --yes -c local sunode
+        conda install --only-deps --yes -c local sunode
+        pip install .
     - name: Run sunode tests
       shell: cmd /C call {0}
       run: |

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -24,7 +24,6 @@ requirements:
     - liblapack
     - cffi
     - sundials >=5.3
-    - theano
   run:
     - python
     - numpy >=1.14

--- a/notebooks/from_sympy.ipynb
+++ b/notebooks/from_sympy.ipynb
@@ -22,17 +22,17 @@
     "\n",
     "import sunode.symode.paramset\n",
     "import sunode.symode.problem\n",
-    "import sunode.wrappers.as_theano\n",
+    "import sunode.wrappers.as_aesara\n",
     "\n",
-    "import theano\n",
-    "import theano.tensor as tt"
+    "import aesara\n",
+    "import aesara.tensor as aet"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Define ode using sympy and theano"
+    "### Define ode using sympy and aesara"
    ]
   },
   {
@@ -41,8 +41,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "b = tt.dvector('b')\n",
-    "d = tt.dvector('d')\n",
+    "b = aet.dvector('b')\n",
+    "d = aet.dvector('d')\n",
     "\n",
     "def rhs(t, y, params):\n",
     "    return {\n",
@@ -53,7 +53,7 @@
     "    }\n",
     "\n",
     "\n",
-    "solution, problem, solver = sunode.wrappers.as_theano.solve_ivp(\n",
+    "solution, problem, solver = sunode.wrappers.as_aesara.solve_ivp(\n",
     "    t0=0,\n",
     "    y0={\n",
     "        'a': (np.arange(3, dtype=float) + d[0] ** 2, 3),\n",
@@ -185,7 +185,7 @@
    "outputs": [],
    "source": [
     "val = (solution ** 2).sum()\n",
-    "grads = tt.grad(val, [b, d])"
+    "grads = aet.grad(val, [b, d])"
    ]
   },
   {
@@ -194,8 +194,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "func = theano.function([b, d], [val] + grads)\n",
-    "func2 = theano.function([b, d], [val])"
+    "func = aesara.function([b, d], [val] + grads)\n",
+    "func2 = aesara.function([b, d], [val])"
    ]
   },
   {
@@ -664,7 +664,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Integrate into theano and check gradients"
+    "### Integrate into aesara and check gradients"
    ]
   },
   {
@@ -682,23 +682,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "params = tt.dvector('params')\n",
-    "y0 = tt.dvector('y0')\n",
-    "solve_ode = sunode.wrappers.as_theano.SolveODEAdjoint(solver, 0, tvals)\n",
+    "params = aet.dvector('params')\n",
+    "y0 = aet.dvector('y0')\n",
+    "solve_ode = sunode.wrappers.as_aesara.SolveODEAdjoint(solver, 0, tvals)\n",
     "solution = solve_ode(y0, params)\n",
     "\n",
     "loss = (solution ** 2).sum()\n",
-    "grad_p, grad_y0 = tt.grad(loss, [params, y0])\n",
-    "func = theano.function([y0, params], [loss, grad_p, grad_y0])\n",
+    "grad_p, grad_y0 = aet.grad(loss, [params, y0])\n",
+    "func = aesara.function([y0, params], [loss, grad_p, grad_y0])\n",
     "\n",
     "# Explicit solution\n",
     "loss = ((\n",
     "    ((0.5 * tvals ** 2 * params[1] + tvals * y0[1]) + y0[0]) ** 2\n",
     "    + (tvals * params[1] + y0[1]) ** 2\n",
     ")).sum()\n",
-    "grad_p, grad_y0 = tt.grad(loss, [params, y0])\n",
+    "grad_p, grad_y0 = aet.grad(loss, [params, y0])\n",
     "\n",
-    "func2 = theano.function([y0, params], [loss, grad_p, grad_y0])"
+    "func2 = aesara.function([y0, params], [loss, grad_p, grad_y0])"
    ]
   },
   {
@@ -842,7 +842,7 @@
     "    params = pm.Normal('params', sd=10, shape=ode.n_params)\n",
     "    y0 = pm.Normal('y0', shape=ode.n_states)\n",
     "    \n",
-    "    solve_ode = sunode.wrappers.as_theano.SolveODEAdjoint(solver, 0, tvals)\n",
+    "    solve_ode = sunode.wrappers.as_aesara.SolveODEAdjoint(solver, 0, tvals)\n",
     "    mu = solve_ode(y0, params)\n",
     "    error = 0.8 * np.random.randn(len(tvals))\n",
     "    pm.Normal('y', mu=mu[:, 0], sd=0.8, observed=tvals ** 2 + tvals + 5 + error)\n",
@@ -980,7 +980,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/pymc3_model.ipynb
+++ b/notebooks/pymc3_model.ipynb
@@ -25,7 +25,7 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "os.environ[\"THEANO_FLAGS\"] = \"floatX=float64\""
+    "os.environ[\"AESARA_FLAGS\"] = \"floatX=float64\""
    ]
   },
   {
@@ -37,7 +37,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "WARNING (theano.configdefaults): install mkl with `conda install mkl-service`: No module named 'mkl'\n"
+      "WARNING (aesara.configdefaults): install mkl with `conda install mkl-service`: No module named 'mkl'\n"
      ]
     }
    ],
@@ -48,8 +48,8 @@
     "from scipy.integrate import odeint\n",
     "\n",
     "import pymc3 as pm\n",
-    "import theano\n",
-    "import theano.tensor as tt\n",
+    "import aesara\n",
+    "import aesara.tensor as aet\n",
     "\n",
     "# this notebook show DEBUG log messages\n",
     "# logging.getLogger('pymc3').setLevel(logging.DEBUG)\n",
@@ -150,9 +150,9 @@
    "outputs": [],
    "source": [
     "# To demonstrate that test-value computation works, but also for debugging\n",
-    "theano.config.compute_test_value = 'raise'\n",
-    "theano.config.exception_verbosity = 'high'\n",
-    "theano.config.traceback.limit = 5"
+    "aesara.config.compute_test_value = 'raise'\n",
+    "aesara.config.exception_verbosity = 'high'\n",
+    "aesara.config.traceback.limit = 5"
    ]
   },
   {
@@ -176,7 +176,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import sunode.wrappers.as_theano\n",
+    "import sunode.wrappers.as_aesara\n",
     "\n",
     "\n",
     "def get_model_sunode():\n",
@@ -187,7 +187,7 @@
     "        s0 = pm.Normal('red_0', mu=10, sd=2)\n",
     "        extra = pm.Normal('extra', shape=n_extra)\n",
     "\n",
-    "        y_hat, _, _ = sunode.wrappers.as_theano.solve_ivp(\n",
+    "        y_hat, _, _ = sunode.wrappers.as_aesara.solve_ivp(\n",
     "            y0={\n",
     "                'S': (s0, ()),  # TODO Infer shape from model?\n",
     "                'P': np.array(y0_true[1], dtype='d'),\n",
@@ -196,7 +196,7 @@
     "            params={\n",
     "                'K_S': (K_S, ()),\n",
     "                'vmax': (vmax, ()),\n",
-    "                'tmp': np.zeros(1),  # TODO theano wants at least one fixed param\n",
+    "                'tmp': np.zeros(1),  # TODO aesara wants at least one fixed param\n",
     "                'extra_p': (extra, (n_extra,))\n",
     "            },\n",
     "            rhs=reaction_sympy,\n",
@@ -235,7 +235,7 @@
     "        \n",
     "        extra = pm.Normal('extra', shape=n_extra)\n",
     "\n",
-    "        y_hat, problem, *args = sunode.wrappers.as_theano.solve_ivp(\n",
+    "        y_hat, problem, _ = sunode.wrappers.as_aesara.solve_ivp(\n",
     "            y0={\n",
     "                'S': (s0, ()),  # TODO Infer shape from model?\n",
     "                'P': np.array(y0_true[1], dtype='d'),\n",
@@ -244,7 +244,7 @@
     "            params={\n",
     "                'K_S': (K_S, ()),\n",
     "                'vmax': (vmax, ()),\n",
-    "                'tmp': np.zeros(1),  # TODO theano wants at least one fixed param\n",
+    "                'tmp': np.zeros(1),  # TODO aesara wants at least one fixed param\n",
     "                'extra_p': (extra, (n_extra,))\n",
     "            },\n",
     "            rhs=reaction_sympy,\n",
@@ -305,22 +305,22 @@
     "    \n",
     "    # create a test function for evaluating the logp value\n",
     "    print('Compiling f_logpt')\n",
-    "    f_logpt = theano.function(\n",
+    "    f_logpt = aesara.function(\n",
     "        inputs=t_inputs,\n",
     "        outputs=[pmodel.logpt],\n",
     "        # with float32, allow downcast because the forward integration is always float64\n",
-    "        allow_input_downcast=(theano.config.floatX == 'float32')\n",
+    "        allow_input_downcast=(aesara.config.floatX == 'float32')\n",
     "    )\n",
     "    print(f'Test logpt:')\n",
     "    print(f_logpt(*test_inputs))\n",
     "    \n",
     "    # and another test function for evaluating the gradient\n",
     "    print('Compiling f_logpt')\n",
-    "    f_grad = theano.function(\n",
+    "    f_grad = aesara.function(\n",
     "        inputs=t_inputs,\n",
-    "        outputs=tt.grad(pmodel.logpt, t_inputs),\n",
+    "        outputs=aet.grad(pmodel.logpt, t_inputs),\n",
     "        # with float32, allow downcast because the forward integration is always float64\n",
-    "        allow_input_downcast=(theano.config.floatX == 'float32')\n",
+    "        allow_input_downcast=(aesara.config.floatX == 'float32')\n",
     "    )\n",
     "    print(f'Test gradient:')\n",
     "    print(f_grad(*test_inputs))\n",
@@ -354,7 +354,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/adr/anaconda3/envs/pymc/lib/python3.7/site-packages/theano/gpuarray/dnn.py:184: UserWarning: Your cuDNN version is more recent than Theano. If you encounter problems, try updating Theano or downgrading cuDNN to a version >= v5 and <= v7.\n",
+      "/home/adr/anaconda3/envs/pymc/lib/python3.7/site-packages/aesara/gpuarray/dnn.py:184: UserWarning: Your cuDNN version is more recent than Aesara. If you encounter problems, try updating Aesara or downgrading cuDNN to a version >= v5 and <= v7.\n",
       "  warnings.warn(\"Your cuDNN version is more recent than \"\n"
      ]
     },
@@ -984,7 +984,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "theano.printing.pydotprint(tt.grad(model_sunode.logpt, model_sunode.vmax), 'ODE_API_shapes_and_benchmarking.png')\n",
+    "aesara.printing.pydotprint(aet.grad(model_sunode.logpt, model_sunode.vmax), 'ODE_API_shapes_and_benchmarking.png')\n",
     "IPython.display.Image('ODE_API_shapes_and_benchmarking.png')"
    ]
   },
@@ -1007,7 +1007,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from theano import d3viz\n",
+    "from aesara import d3viz\n",
     "d3viz.d3viz(model.logpt, 'ODE_API_shapes_and_benchmarking.html')"
    ]
   },
@@ -1035,7 +1035,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,22 @@
+import os
+import re
 from setuptools import setup, find_packages
+
+
+def get_version():
+    VERSIONFILE = os.path.join("sunode", "__init__.py")
+    lines = open(VERSIONFILE).readlines()
+    version_regex = r"^__version__ = ['\"]([^'\"]*)['\"]"
+    for line in lines:
+        mo = re.search(version_regex, line, re.M)
+        if mo:
+            return mo.group(1)
+    raise RuntimeError(f"Unable to find version in {VERSIONFILE}.")
+
 
 setup(
     name='sunode',
-    version='0.1.1',
+    version=get_version(),
     author='Adrian Seyboldt',
     author_email='adrian.seyboldt@gmail.com',
     description='Python wrapper of sundials for solving ordinary differential equations',

--- a/sunode/__init__.py
+++ b/sunode/__init__.py
@@ -5,6 +5,9 @@ from sunode.matrix import empty_matrix
 from sunode.symode import SympyProblem
 import sunode.solver
 
+
+__version__ = "0.1.1"
+
 __all__ = [
     "empty_matrix",
     "empty_vector",

--- a/sunode/solver.py
+++ b/sunode/solver.py
@@ -212,7 +212,7 @@ class BaseSolver(Borrows):
 
 class Solver:
     def __init__(self, problem: Problem, *,
-                 compute_sens: bool = False, abstol: float = 1e-10, reltol: float = 1e-10,
+                 abstol: float = 1e-10, reltol: float = 1e-10,
                  sens_mode: Optional[str] = None, scaling_factors: Optional[np.ndarray] = None,
                  constraints: Optional[np.ndarray] = None, solver='BDF'):
         self._problem = problem
@@ -247,8 +247,8 @@ class Solver:
         user_data_p = ffi.cast('void *', ffi.addressof(ffi.from_buffer(self._user_data.data)))
         check(lib.CVodeSetUserData(self._ode, user_data_p))
 
-        self._compute_sens = compute_sens
-        if compute_sens:
+        self._compute_sens = sens_mode is not None
+        if self._compute_sens:
             sens_rhs = self._problem.make_sundials_sensitivity_rhs()
             self._init_sens(sens_rhs, sens_mode)
 

--- a/sunode/wrappers/as_theano.py
+++ b/sunode/wrappers/as_theano.py
@@ -135,6 +135,8 @@ def solve_ivp(
         solution = problem.flat_solution_as_dict(flat_solution)
         return solution, flat_solution, problem, sol, y0_flat, params_subs_flat
     elif derivatives == 'forward':
+        if not "sens_mode" in solver_kwargs:
+            raise ValueError("When `derivatives=True`, the `solver_kwargs` must contain one of `sens_mode={\"simultaneous\" | \"staggered\"}`.")
         sol = solver.Solver(problem, **solver_kwargs)
         wrapper = SolveODE(sol, t0, tvals)
         flat_solution, flat_sens = wrapper(y0_flat, params_subs_flat, params_remaining_flat)


### PR DESCRIPTION
There are three important releases of the backends:
+ `theano v1.0.5` (the last "original" version)
+ `theano-pymc v1.1.2` (the last version before Aesara; used by PyMC3 v3.11.1)
+ `aesara v2` used by PyMC3 master and upcoming PyMC3 `v4`

I flexibilized the imports to be compatible with all three.

ToDo:
+ [ ] The Github Actions failures are dealt with in #15 - this branch is forked from #15
+ [ ] Tests should be added to cover `as_theano.py` with all three backend versions mentioned above
+ [ ] Actually run the notebooks

@aseyboldt @astoeriko would you prefer to release a version that supports both Theano(-PyMC) and Aesara, or just a major bump that fully switches over?