### PR TITLE
Fix equation formatting in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,10 @@ pip install -e .
 We will use the Lotka-Volterra equations as an example ODE:
 
 $$
-\freq{dH}{dt} = \alpha H - \beta LH\\
-\freq{dL}{dt} = \delta LH - \gamma L
+\begin{gather}
+\frac{dH}{dt} = \alpha H - \beta LH\\
+\frac{dL}{dt} = \delta LH - \gamma L
+\end{gather}
 $$
 
 ```python


### PR DESCRIPTION
Now that github can finally render equations in markdown files, I noticed that there was a typo in the example ODE in the Readme. The typo prevented the correct rendering of the equation. This pull request simply fixes the equation formatting.