### PR TITLE
Use `pytest-cov` to report coverage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependences
       run: |
-        conda install --yes conda-build conda-verify coverage pytest hypothesis statsmodels aesara c-compiler
+        conda install --yes conda-build conda-verify pytest pytest-cov hypothesis statsmodels aesara c-compiler
     - name: Build package
       run: |
         conda build --variants "{python: [${{ matrix.python-version }}]}" ./sunode/conda
@@ -38,4 +38,4 @@ jobs:
     - name: Test with coverage
       run: |
         # conda activate doesn't seem to set paths to the conda prefix correctly
-        env LD_LIBRARY_PATH=${CONDA_PREFIX}/lib coverage run -m pytest --pyargs sunode
+        env LD_LIBRARY_PATH=${CONDA_PREFIX}/lib pytest --cov=sunode --cov-report xml --cov-report term-missing sunode


### PR DESCRIPTION
I noticed that the test pipeline didn't report the coverage: https://github.com/aseyboldt/sunode/runs/7337771568?check_suite_focus=true#step:7:15

Also, I have a hunch that #35 might be a bug that is caused by some code never executing, which should be easy to spot in the coverage report.